### PR TITLE
Update WebKitGTK to 2.20.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: These libraries can require additional installations if you haven't such. 
 - `zeromq=4.3` distributed messaging
 - `spdlog=1.4.1` logging library
 - `gtest=1.8.1` for tests
-- `webkitgtk>=2.4.10` web content rendering
+- `webkit2gtk>=2.20.5` web content rendering
 - `Boost.System, Boost.Filesystem, Boost.Date_Time, Boost.Thread=1.70` 
 
 ### Building with Docker (only for Ubuntu 18.04)

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -12,7 +12,7 @@ pkg_check_modules(GSTREAMER REQUIRED
     gstreamer-pbutils-1.0>=1.16.2
     gstreamer-plugins-base-1.0>=1.16.2
     gstreamer-video-1.0>=1.16.2)
-pkg_check_modules(WEBKITGTK REQUIRED webkitgtk-3.0>=2.4.10)
+pkg_check_modules(WEBKITGTK REQUIRED webkit2gtk-4.0>=2.20.5)
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0>=3.22.0)
 pkg_check_modules(GLIBMM REQUIRED glibmm-2.4>=2.56.0)
 pkg_check_modules(X11 REQUIRED x11)

--- a/player/control/media/webview/WebViewGtk.cpp
+++ b/player/control/media/webview/WebViewGtk.cpp
@@ -2,7 +2,7 @@
 
 #include "common/types/Uri.hpp"
 
-#include <webkit/webkit.h>
+#include <webkit2/webkit2.h>
 
 namespace ph = std::placeholders;
 
@@ -50,7 +50,9 @@ void WebViewGtk::enableTransparency()
     handler_.signal_screen_changed().connect(std::bind(&WebViewGtk::screenChanged, this, ph::_1));
     screenChanged(handler_.get_screen());
 
-    webkit_web_view_set_transparent(webView_, true);
+    GdkRGBA background_color;
+    gdk_rgba_parse(&background_color, "rgba(0,0,0,0)");
+    webkit_web_view_set_background_color(webView_, &background_color);
 }
 
 void WebViewGtk::screenChanged(const Glib::RefPtr<Gdk::Screen>& screen)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
       - wget
       - unzip
       - libgtkmm-3.0-dev 
-      - libwebkitgtk-3.0-dev
+      - libwebkit2gtk-4.0-dev
       - libxss-dev
       - libglibmm-2.4-dev
       - libssl-dev
@@ -197,7 +197,7 @@ parts:
       - libboost1.70
       - libgtkmm-3.0-1v5
       - libcanberra-gtk3-module
-      - libwebkitgtk-3.0-0
+      - libwebkit2gtk-4.0-dev
       - libgpm2 # gstreamer warning
       - libslang2 # gstreamer warning
     after: [zmq, boost, spdlog, gtest] 


### PR DESCRIPTION
This updates the included WebKitGTK version from [2.4.10](https://packages.ubuntu.com/xenial/libwebkitgtk-3.0-dev) (released 2016-03-14) to [2.20.5](https://packages.ubuntu.com/xenial/libwebkit2gtk-4.0-dev) (released 2018-08-13).

Newer is not always better but a lot has changed in the web in the last 4 years. For example, xibo-linux now supports flexboxes in HTML layouts which previously didn't work properly. Arguably the new version is not exactly "state of the art" either. When Ubuntu 20.04 is released, the snap base should be changed accordingly to pull in an even newer version.

The API has changed a bit but luckily the changes in this project are marginal.