### PR TITLE
Issue #172 fix

### DIFF
--- a/player/common/PlayerRuntimeError.hpp
+++ b/player/common/PlayerRuntimeError.hpp
@@ -6,7 +6,7 @@
 class PlayerRuntimeError : public std::exception
 {
 public:
-    PlayerRuntimeError(std::string_view domain, std::string_view message) :
+    PlayerRuntimeError(const std::string& domain, const std::string& message) :
         domain_(domain),
         message_(message),
         what_("[" + domain_ + "] " + message_)

--- a/player/control/ApplicationWindow.hpp
+++ b/player/control/ApplicationWindow.hpp
@@ -72,6 +72,10 @@ public:
             setMainLayout(splashScreen);
             splashScreen->show();
         }
+        catch (PlayerRuntimeError& e)
+        {
+            Log::error("[SplashScreen] {}", e.message());
+        }
         catch (std::exception& e)
         {
             Log::error("[SplashScreen] {}", e.what());
@@ -95,7 +99,9 @@ public:
 
     void setSize(int width, int height) override
     {
-        if (shouldBeFullscreen(width, height))
+        auto [adjustedWidth, adjustedHeight] = adjustSize(width, height);
+
+        if (shouldBeFullscreen(adjustedWidth, adjustedHeight))
         {
             Window::fullscreen();
         }
@@ -105,7 +111,7 @@ public:
             {
                 Window::unfullscreen();
             }
-            Window::setSize(width, height);
+            Window::setSize(adjustedWidth, adjustedHeight);
         }
 
         statusScreen_->setSize(static_cast<int>(this->width() * StatusScreenScaleX),
@@ -118,6 +124,16 @@ private:
             StatusScreenFactory::create(static_cast<Window&>(*this), MinStatusScreenWidth, MinStatusScreenHeight))
     {
         assert(statusScreen_);
+    }
+
+    std::pair<int, int> adjustSize(int width, int height)
+    {
+        if (width < 0 || height < 0)
+        {
+            Log::error("[ApplicationWindow] Negative size is not allowed, falling back to fullscreen mode");
+            return {0, 0};
+        }
+        return {width, height};
     }
 
     void setMainContainer(const std::shared_ptr<Xibo::OverlayContainer>& widget)

--- a/player/control/layout/LayoutsManager.cpp
+++ b/player/control/layout/LayoutsManager.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<Xibo::MainLayout> LayoutsManager::createLayout(int layoutId)
     }
     catch (std::exception& e)
     {
-        Log::error("[LayoutsManager] {}", e.what());
+        Log::error(e.what());
         Log::info("[LayoutsManager] Check resource folder to find out what happened");
     }
 

--- a/player/control/layout/MainLayoutParser.cpp
+++ b/player/control/layout/MainLayoutParser.cpp
@@ -11,7 +11,10 @@
 const std::string DefaultColor = "#000";
 const bool DefaultStatsEnabled = false;
 
-using namespace std::string_literals;
+MainLayoutParser::Error::Error(const std::string& domain, int layoutId, const std::string& reason) :
+    PlayerRuntimeError{domain, "Layout " + std::to_string(layoutId) + " is invalid or missing. Reason: " + reason}
+{
+}
 
 std::unique_ptr<Xibo::MainLayout> MainLayoutParser::parseBy(int layoutId)
 {
@@ -23,10 +26,13 @@ std::unique_ptr<Xibo::MainLayout> MainLayoutParser::parseBy(int layoutId)
         auto root = Parsing::xmlFrom(xlfFile);
         return layoutFrom(root.get_child(XlfResources::LayoutNode));
     }
+    catch (PlayerRuntimeError& e)
+    {
+        throw MainLayoutParser::Error{"LayoutParser - " + e.domain(), layoutId, e.message()};
+    }
     catch (std::exception& e)
     {
-        std::string message = "Layout " + std::to_string(layoutId) + " is invalid or missing. Reason: ";
-        throw MainLayoutParser::Error("MainLayoutParser", message + e.what());
+        throw MainLayoutParser::Error{"LayoutParser", layoutId, e.what()};
     }
 }
 

--- a/player/control/layout/MainLayoutParser.hpp
+++ b/player/control/layout/MainLayoutParser.hpp
@@ -14,7 +14,7 @@ public:
 
     struct Error : PlayerRuntimeError
     {
-        using PlayerRuntimeError::PlayerRuntimeError;
+        Error(const std::string& domain, int layoutId, const std::string& reason);
     };
 
     std::unique_ptr<Xibo::MainLayout> parseBy(int layoutId);

--- a/player/control/media/MediaParser.cpp
+++ b/player/control/media/MediaParser.cpp
@@ -122,9 +122,13 @@ std::unique_ptr<Xibo::Media> MediaParser::mediaFrom(const XmlNode& node, int par
 
         return media;
     }
+    catch (PlayerRuntimeError& e)
+    {
+        throw MediaParser::Error{"MediaParser - " + e.domain(), e.message()};
+    }
     catch (std::exception& e)
     {
-        throw MediaParser::Error{"MediaParser", "Media is invalid. Reason: "s + e.what()};
+        throw MediaParser::Error{"MediaParser", e.what()};
     }
 }
 

--- a/player/control/region/RegionParser.cpp
+++ b/player/control/region/RegionParser.cpp
@@ -5,7 +5,7 @@
 
 #include "control/media/MediaParsersRepo.hpp"
 
-const int DefaultRegionZindex = 0;
+const int DefaultRegionZorder = 0;
 const bool DefaultRegionLoop = false;
 
 using namespace std::string_literals;
@@ -22,30 +22,27 @@ std::unique_ptr<Xibo::Region> RegionParser::regionFrom(const XmlNode& node)
     }
     catch (PlayerRuntimeError& e)
     {
-        throw RegionParser::Error{"RegionParser - " + e.domain(), e.message()};
+        throw Error{"RegionParser - " + e.domain(), e.message()};
     }
     catch (std::exception& e)
     {
-        throw RegionParser::Error{"RegionParser", e.what()};
+        throw Error{"RegionParser", e.what()};
     }
 }
 
 RegionPosition RegionParser::positionFrom(const XmlNode& node)
 {
-    try
-    {
-        RegionPosition position;
+    RegionPosition position;
 
-        position.left = static_cast<int>(node.get<float>(XlfResources::Region::Left));
-        position.top = static_cast<int>(node.get<float>(XlfResources::Region::Top));
-        position.zorder = node.get<int>(XlfResources::Region::Zindex, DefaultRegionZindex);
-
-        return position;
-    }
-    catch (std::exception& e)
+    position.left = static_cast<int>(node.get<float>(XlfResources::Region::Left));
+    position.top = static_cast<int>(node.get<float>(XlfResources::Region::Top));
+    position.zorder = node.get<int>(XlfResources::Region::Zindex, DefaultRegionZorder);
+    if (position.zorder < 0)
     {
-        throw RegionParser::Error{"RegionParser", "Position is invalid. Reason: "s + e.what()};
+        position.zorder = DefaultRegionZorder;
     }
+
+    return position;
 }
 
 RegionOptions RegionParser::optionsFrom(const XmlNode& node)

--- a/player/control/region/RegionParser.cpp
+++ b/player/control/region/RegionParser.cpp
@@ -20,9 +20,13 @@ std::unique_ptr<Xibo::Region> RegionParser::regionFrom(const XmlNode& node)
 
         return region;
     }
+    catch (PlayerRuntimeError& e)
+    {
+        throw RegionParser::Error{"RegionParser - " + e.domain(), e.message()};
+    }
     catch (std::exception& e)
     {
-        throw RegionParser::Error{"RegionParser", "Region is invalid. Reason: "s + e.what()};
+        throw RegionParser::Error{"RegionParser", e.what()};
     }
 }
 

--- a/player/control/widgets/FixedContainer.hpp
+++ b/player/control/widgets/FixedContainer.hpp
@@ -30,11 +30,6 @@ struct ChildInfo
 template <typename Base>
 class FixedContainer : public Container<Base, ChildInfo>
 {
-    struct Error : public PlayerRuntimeError
-    {
-        using PlayerRuntimeError::PlayerRuntimeError;
-    };
-
     friend std::unique_ptr<Xibo::FixedContainer> FixedContainerFactory::create(int width, int height);
 
 public:
@@ -50,8 +45,7 @@ public:
     void reorder(const std::shared_ptr<Xibo::Widget>& widget, int zorder) override
     {
         assert(widget);
-
-        check(zorder);
+        assert(zorder >= 0);
 
         reorderInHandler(widget, zorder);
     }
@@ -77,7 +71,7 @@ protected:
         {
             int zorder = static_cast<int>(i);
 
-            check(zorder);
+            assert(zorder >= 0);
             reorder(this->children()[i].widget, zorder);
         }
     }
@@ -87,10 +81,5 @@ protected:
         std::stable_sort(this->children().begin(), this->children().end(), [=](const auto& first, const auto& second) {
             return first.info.zorder < second.info.zorder;
         });
-    }
-
-    void check(int zorder)
-    {
-        if (zorder < 0) throw Error{"FixedContainer", "Zorder should be non-negative"};
     }
 };


### PR DESCRIPTION
1. If sizeX/sizeY in display settings is negative we consider it 0 and go to fullscreen mode.
2. XLF parse errors are logged in a more readable form.
3. If zorder is negative for some reason we consider it 0 and don't throw any exception