### PR TITLE
feat: print stack trace in case of SIGSEGV and SIGABRT

### DIFF
--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -16,10 +16,15 @@ set(CMAKE_TESTS_DIRECTORY ${CMAKE_BINARY_DIR}/bin/tests/)
 add_compile_options(
     -static-libstdc++ -pthread -Wall -Wno-parentheses -Wno-cast-function-type -W -Wunused-variable -Wunused-parameter -Wunused-function -Wunused -Wno-system-headers -Wno-deprecated -Woverloaded-virtual -Wwrite-strings
     "$<$<CONFIG:RELEASE>:-O2>"
-    "$<$<CONFIG:DEBUG>:-g;-O0>"
+    "$<$<CONFIG:DEBUG>:-g3;-O0>"
 )
 
-add_compile_definitions(BOOST_THREAD_PROVIDES_FUTURE BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION)
+add_compile_definitions(
+    BOOST_THREAD_PROVIDES_FUTURE
+    BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+    BOOST_STACKTRACE_USE_ADDR2LINE
+    BOOST_STACKTRACE_USE_BACKTRACE
+)
 
 option(SNAP_BUILD "Use SNAP environment during build" OFF)
 if(SNAP_BUILD)
@@ -47,6 +52,8 @@ target_link_libraries(${PROJECT_NAME}
     config
     control
     system
+    dl
+    backtrace
 )
 
 configure_file(ui.glade ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ui.glade COPYONLY)

--- a/player/main.cpp
+++ b/player/main.cpp
@@ -1,9 +1,28 @@
 #include "XiboApp.hpp"
-
 #include "common/logger/Logging.hpp"
+
+#include <boost/stacktrace.hpp>
+#include <iostream>
+#include <signal.h>
+
+/* DISCLAIMER
+ * Boost provide boost::stacktrace::stacktrace::safe_dump_to which statisfies the signal-safety
+ * requirements, however, it gives very unuseful stacktrace without function names/lines. So we
+ * decide to go with unsafe stacktrace taking into account we call it in SIGSEGV and SIGABRT
+ * signal handlers which are already the indicators of fatal error
+ */
+void signalStacktraceHandler(int signum)
+{
+    signal(signum, SIG_DFL);
+    std::cout << boost::stacktrace::stacktrace() << std::endl;
+    raise(signum);
+}
 
 int main(int /*argc*/, char** /*argv*/)
 {
+    signal(SIGSEGV, &signalStacktraceHandler);
+    signal(SIGABRT, &signalStacktraceHandler);
+
     try
     {
         auto&& app = XiboApp::create("org.gtkmm.xibo");


### PR DESCRIPTION
We print stack trace using boost::stacktrace::stacktrace() which is not the safest way to do it in a
signal handler however it gives us more info if compared to safe call. xibosignage#184