### PR TITLE
feat: use unique XMR channel for player

### DIFF
--- a/player/XiboApp.cpp
+++ b/player/XiboApp.cpp
@@ -84,7 +84,8 @@ XiboApp::XiboApp(const std::string& name) :
 
 std::unique_ptr<XmrManager> XiboApp::createXmrManager()
 {
-    auto manager = std::make_unique<XmrManager>();
+    auto xmrChannel = XmrChannel::fromCmsSettings(cmsSettings_.address(), cmsSettings_.key(), cmsSettings_.displayId());
+    auto manager = std::make_unique<XmrManager>(xmrChannel);
 
     manager->connect(playerSettings_.xmrNetworkAddress());
     playerSettings_.xmrNetworkAddress().valueChanged().connect(std::bind(&XmrManager::connect, manager.get(), ph::_1));

--- a/player/cms/CMakeLists.txt
+++ b/player/cms/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(${PROJECT_NAME}
     stat
     schedule
     crypto
+    xmr
 )
 
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/player/cms/xmds/XmdsRequestSender.cpp
+++ b/player/cms/xmds/XmdsRequestSender.cpp
@@ -5,7 +5,7 @@
 
 #include "common/crypto/RsaManager.hpp"
 #include "common/system/System.hpp"
-#include "config/AppConfig.hpp"
+#include "xmr/XmrChannel.hpp"
 
 const std::string DefaultClientType = "linux";
 const std::string XmdsTarget = "/xmds.php?v=5";
@@ -14,6 +14,7 @@ XmdsRequestSender::XmdsRequestSender(const std::string& host,
                                      const std::string& serverKey,
                                      const std::string& hardwareKey) :
     uri_(Uri::fromString(host + XmdsTarget)),
+    host_(host),
     serverKey_(serverKey),
     hardwareKey_(hardwareKey)
 {
@@ -30,7 +31,7 @@ FutureResponseResult<RegisterDisplay::Result> XmdsRequestSender::registerDisplay
     request.clientCode = clientCode;
     request.clientVersion = clientVersion;
     request.macAddress = static_cast<std::string>(System::macAddress());
-    request.xmrChannel = AppConfig::mainXmrChannel();
+    request.xmrChannel = static_cast<std::string>(XmrChannel::fromCmsSettings(host_, serverKey_, hardwareKey_));
     request.xmrPubKey = CryptoUtils::keyToString(RsaManager::instance().publicKey());
     request.displayName = displayName;
 

--- a/player/cms/xmds/XmdsRequestSender.hpp
+++ b/player/cms/xmds/XmdsRequestSender.hpp
@@ -2,7 +2,6 @@
 
 #include <boost/thread/future.hpp>
 
-#include "networking/ResponseResult.hpp"
 #include "cms/xmds/GetFile.hpp"
 #include "cms/xmds/GetResource.hpp"
 #include "cms/xmds/MediaInventory.hpp"
@@ -12,6 +11,7 @@
 #include "cms/xmds/SubmitLog.hpp"
 #include "cms/xmds/SubmitScreenShot.hpp"
 #include "cms/xmds/SubmitStats.hpp"
+#include "networking/ResponseResult.hpp"
 
 #include "common/types/Uri.hpp"
 
@@ -40,6 +40,7 @@ public:
 
 private:
     Uri uri_;
+    std::string host_;
     std::string serverKey_;
     std::string hardwareKey_;
 };

--- a/player/config/AppConfig.cpp
+++ b/player/config/AppConfig.cpp
@@ -28,11 +28,6 @@ std::string AppConfig::codeVersion()
 #endif
 }
 
-std::string AppConfig::mainXmrChannel()
-{
-    return "playerLinux";
-}
-
 FilePath AppConfig::resourceDirectory()
 {
     return resourceDirectory_;

--- a/player/config/AppConfig.hpp
+++ b/player/config/AppConfig.hpp
@@ -8,8 +8,6 @@ public:
     static std::string version();      // TODO: strong type
     static std::string codeVersion();  // TODO: strong type
 
-    static std::string mainXmrChannel();
-
     static FilePath resourceDirectory();
     static void resourceDirectory(const FilePath& directory);
     static FilePath buildDirectory();

--- a/player/options/MainWindowController.cpp
+++ b/player/options/MainWindowController.cpp
@@ -9,6 +9,8 @@
 #include "common/system/System.hpp"
 #include "config/AppConfig.hpp"
 
+const std::string DefaultDisplay = "Display";
+
 MainWindowController::MainWindowController(Gtk::Window* window, const Glib::RefPtr<Gtk::Builder>& ui) :
     ui_(ui),
     mainWindow_(window)
@@ -86,15 +88,16 @@ std::string MainWindowController::connectToCms(const std::string& cmsAddress,
     {
         XmdsRequestSender xmdsRequester{cmsAddress, key, displayId};
 
-        auto connectionResult = xmdsRequester.registerDisplay(AppConfig::codeVersion(), AppConfig::version(), "Display")
-                                    .then([](auto future) {
-                                        auto [error, result] = future.get();
+        auto connectionResult =
+            xmdsRequester.registerDisplay(AppConfig::codeVersion(), AppConfig::version(), DefaultDisplay)
+                .then([](auto future) {
+                    auto [error, result] = future.get();
 
-                                        if (!error)
-                                            return result.status.message;
-                                        else
-                                            return error.message();
-                                    });
+                    if (!error)
+                        return result.status.message;
+                    else
+                        return error.message();
+                });
 
         return connectionResult.get();
     }

--- a/player/xmr/CMakeLists.txt
+++ b/player/xmr/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(${PROJECT_NAME}
     XmrManager.cpp
     XmrManager.hpp
     XmrStatus.hpp
+    XmrChannel.hpp
+    XmrChannel.cpp
     zmq/Context.cpp
     zmq/Context.cpp
     zmq/Exception.cpp

--- a/player/xmr/XmrChannel.cpp
+++ b/player/xmr/XmrChannel.cpp
@@ -1,0 +1,11 @@
+#include "XmrChannel.hpp"
+
+#include "common/crypto/Md5Hash.hpp"
+
+XmrChannel XmrChannel::fromCmsSettings(const std::string& host,
+                                       const std::string& cmsKey,
+                                       const std::string& hardwareKey)
+{
+    auto hash = Md5Hash::fromString(host + cmsKey + hardwareKey);
+    return XmrChannel{static_cast<std::string>(hash)};
+}

--- a/player/xmr/XmrChannel.hpp
+++ b/player/xmr/XmrChannel.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "common/types/internal/StrongType.hpp"
+
+#include <string>
+
+struct XmrChannel : StrongType<std::string>
+{
+    using StrongType::StrongType;
+
+    static XmrChannel fromCmsSettings(const std::string& host,
+                                      const std::string& cmsKey,
+                                      const std::string& hardwareKey);
+};

--- a/player/xmr/XmrManager.cpp
+++ b/player/xmr/XmrManager.cpp
@@ -13,7 +13,8 @@ const size_t KEY_PART = 1;
 const size_t MESSAGE_PART = 2;
 
 const char* const HearbeatChannel = "H";
-const Zmq::Channels XmrChannels{AppConfig::mainXmrChannel(), HearbeatChannel};
+
+XmrManager::XmrManager(const XmrChannel& mainChannel) : mainChannel_(static_cast<std::string>(mainChannel)) {}
 
 // TODO: strong type
 void XmrManager::connect(const std::string& host)
@@ -23,7 +24,7 @@ void XmrManager::connect(const std::string& host)
     info_.host = host;
     subscriber_.messageReceived().connect(
         [this](const Zmq::MultiPartMessage& message) { processMultipartMessage(message); });
-    subscriber_.run(host, XmrChannels);
+    subscriber_.run(host, Zmq::Channels{mainChannel_, HearbeatChannel});
 }
 
 void XmrManager::stop()
@@ -48,7 +49,7 @@ XmrStatus XmrManager::status()
 
 void XmrManager::processMultipartMessage(const Zmq::MultiPartMessage& multipart)
 {
-    if (multipart[CHANNEL_PART] == AppConfig::mainXmrChannel())
+    if (multipart[CHANNEL_PART] == mainChannel_)
     {
         try
         {

--- a/player/xmr/XmrManager.hpp
+++ b/player/xmr/XmrManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/dt/DateTime.hpp"
+#include "xmr/XmrChannel.hpp"
 #include "xmr/XmrStatus.hpp"
 #include "xmr/zmq/Subscriber.hpp"
 
@@ -19,6 +20,8 @@ using ScreenshotAction = boost::signals2::signal<void()>;
 class XmrManager
 {
 public:
+    XmrManager(const XmrChannel& mainChannel);
+
     void connect(const std::string& host);
     void stop();
 
@@ -34,6 +37,7 @@ private:
     bool isMessageExpired(const XmrMessage& message);
 
 private:
+    std::string mainChannel_;
     Zmq::Subscriber subscriber_;
     CollectionIntervalAction collectionIntervalAction_;
     ScreenshotAction screenshotAction_;


### PR DESCRIPTION
Now we are using unique identifier for XMR channel to avoid nasty errors
when multiple displays have the same hardcoded XMR channel.  xibosignage#124