### PR TITLE
fix: add current drive detection xibosignage#238

### DIFF
--- a/player/common/system/HardwareKeyGenerator.hpp
+++ b/player/common/system/HardwareKeyGenerator.hpp
@@ -2,7 +2,8 @@
 
 #include "common/system/HardwareKey.hpp"
 
-#include <boost/process/io.hpp>
+#include <ios>
+#include <regex>
 #include <string>
 
 class HardwareKeyGenerator
@@ -15,5 +16,7 @@ private:
     static void nativeCpuid(unsigned int* eax, unsigned int* ebx, unsigned int* ecx, unsigned int* edx);
     static std::string macAddress();
     static std::string volumeSerial();
-    static std::string retrieveVolumeSerial(boost::process::ipstream& stream);
+    static std::string currentDrive();
+    static std::string executeAndGrepFirstLine(const std::string& command, const std::string& grepSearch);
+    static std::string retrieveResult(const std::regex& regex, const std::string& line);
 };


### PR DESCRIPTION
The problem was that I'd always used harcoded `/dev/sda` as a main device where the player should be stored. This is wrong at least for 2 reasons:
1. Player can be saved on a flash drive (which can be `/dev/sdb` or something else)
2. `/dev/sda` is not always the name of the main drive

I'm using `df /player/binary/location` now to determine the storage device. 

WARNING: potentially it could change display ID (hash will be changed) for some users - e.g. they had `/dev/sda` on the machine but were using `/dev/sdb` to store player binary. Because it should determine the location correctly now it will change the display's hash.