### PR TITLE
fix: add missing logging args and context

### DIFF
--- a/player/cms/CollectionInterval.cpp
+++ b/player/cms/CollectionInterval.cpp
@@ -257,7 +257,7 @@ void CollectionInterval::submitStats()
     }
     catch (const std::exception& e)
     {
-        Log::error(e.what());
+        Log::error("[CollectionInterval] {}", e.what());
         Log::error("[CollectionInterval] Failed to submit stats");
     }
 }

--- a/player/cms/RequiredFilesDownloader.cpp
+++ b/player/cms/RequiredFilesDownloader.cpp
@@ -26,7 +26,7 @@ bool RequiredFilesDownloader::onRegularFileDownloaded(const ResponseContentResul
     }
     else
     {
-        Log::error("[{}] Download error: {}", file.name());
+        Log::error("[{}] Download error: {}", file.name(), error);
         return false;
     }
 }

--- a/player/common/logger/XmlLogsRetriever.cpp
+++ b/player/common/logger/XmlLogsRetriever.cpp
@@ -29,8 +29,8 @@ std::string XmlLogsRetriever::formatLogs(const std::string& logs)
     }
     catch (std::exception& e)
     {
-        Log::error("[XmlLogsRetriever] Format logs error: ", e.what());
-        Log::trace(logs);
+        Log::error("[XmlLogsRetriever] Format logs error: {}", e.what());
+        Log::trace("[XmlLogsRetriever] {}", logs);
     }
 
     return {};

--- a/player/control/layout/LayoutsManager.cpp
+++ b/player/control/layout/LayoutsManager.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<Xibo::MainLayout> LayoutsManager::createLayout(int layoutId)
             }
             catch (const std::exception& e)
             {
-                Log::error(e.what());
+                Log::error("[LayoutsManager] {}", e.what());
             }
         });
         layout->mediaStatsReady().connect([this, layoutId, scheduleId](const MediaPlayingTime& intervals) {
@@ -115,7 +115,7 @@ std::unique_ptr<Xibo::MainLayout> LayoutsManager::createLayout(int layoutId)
             }
             catch (const std::exception& e)
             {
-                Log::error(e.what());
+                Log::error("[LayoutsManager] {}", e.what());
             }
         });
 
@@ -136,7 +136,7 @@ std::unique_ptr<Xibo::MainLayout> LayoutsManager::createLayout(int layoutId)
     }
     catch (std::exception& e)
     {
-        Log::error(e.what());
+        Log::error("[LayoutsManager] {}", e.what());
         Log::info("[LayoutsManager] Check resource folder to find out what happened");
     }
 

--- a/player/schedule/LayoutSchedule.cpp
+++ b/player/schedule/LayoutSchedule.cpp
@@ -16,7 +16,7 @@ LayoutSchedule LayoutSchedule::fromFile(const FilePath& path)
     }
     catch (std::exception& e)
     {
-        Log::error(e.what());
+        Log::error("[LayoutSchedule] {}", e.what());
     }
     return {};
 }
@@ -30,7 +30,7 @@ LayoutSchedule LayoutSchedule::fromString(const std::string& string)
     }
     catch (std::exception& e)
     {
-        Log::error(e.what());
+        Log::error("[LayoutSchedule] {}", e.what());
     }
     return {};
 }
@@ -44,7 +44,7 @@ void LayoutSchedule::toFile(const FilePath& path) const
     }
     catch (std::exception& e)
     {
-        Log::error(e.what());
+        Log::error("[LayoutSchedule] {}", e.what());
     }
 }
 


### PR DESCRIPTION
In the log output, I sometimes see
```
[*** LOG ERROR #0045 ***] [2021-10-27 02:42:31] [logger] {argument index out of range}
```
which seems like it should be fixed by this change.

I also added a `[...]` context everywhere that an exception message was just logged without context.