### PR TITLE
fix: file cache operations concurrent access ensured with a mutex

### DIFF
--- a/player/common/storage/FileCacheImpl.cpp
+++ b/player/common/storage/FileCacheImpl.cpp
@@ -145,9 +145,12 @@ void FileCacheImpl::addToCache(const std::string& filename, const Md5Hash& hash,
     node.put(Md5Attr, hash);
     node.put(ValidAttr, hash == target);
 
+    /* critical section, access and modify file cache buffer */
+    fileCacheMutex_.lock();
     fileCache_.put_child(fullPath(filename), node);
 
     saveFileHashes(cacheFile_);
+    fileCacheMutex_.unlock();
 }
 
 void FileCacheImpl::addToCache(const std::string& filename, const Md5Hash& hash, const DateTime& lastUpdate)
@@ -157,9 +160,12 @@ void FileCacheImpl::addToCache(const std::string& filename, const Md5Hash& hash,
     node.put(LastUpdateAttr, lastUpdate.timestamp());
     node.put(ValidAttr, true);
 
+    /* critical section, access and modify file cache buffer */
+    fileCacheMutex_.lock();
     fileCache_.put_child(fullPath(filename), node);
 
     saveFileHashes(cacheFile_);
+    fileCacheMutex_.unlock();
 }
 
 void FileCacheImpl::loadFileHashes(const FilePath& path)

--- a/player/common/storage/FileCacheImpl.hpp
+++ b/player/common/storage/FileCacheImpl.hpp
@@ -4,6 +4,7 @@
 #include "common/storage/FileCache.hpp"
 
 #include <boost/noncopyable.hpp>
+#include <boost/thread/mutex.hpp>
 
 class FileCacheImpl : public FileCache, public XmlDefaultFileHandler, private boost::noncopyable
 {
@@ -31,6 +32,7 @@ private:
     void saveFileHashes(const FilePath& path);
 
 private:
+    boost::mutex fileCacheMutex_;
     XmlNode fileCache_;
     FilePath cacheFile_;
 };


### PR DESCRIPTION
A quick fix to ensure file downloader threads won't corrupt file cache (or segfault and crash xibo-player) , while trying to save it with fileCache_.save(...)